### PR TITLE
update the version of dune files to autogenerate opam files correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# dev
+
+- Update licensing metadata.
+- Update dune files to 2.7 to autogenerate opam files correctly (#2)
+
 # Release 5.0  (2021-06-29)
 
 - Initial import from OCaml 4.14

--- a/camlp-streams.opam
+++ b/camlp-streams.opam
@@ -31,11 +31,12 @@ authors: ["Daniel de Rauglaudre" "Xavier Leroy"]
 homepage: "https://github.com/ocaml/camlp-streams"
 bug-reports: "https://github.com/ocaml/camlp-streams/issues"
 depends: [
-  "dune" {>= "2.5"}
+  "dune" {>= "2.7"}
   "ocaml" {>= "4.05.0"}
+  "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.5)
+(lang dune 2.7)
 (generate_opam_files true)
 (formatting disabled)
 


### PR DESCRIPTION
- Before dune 2.7, the wrong pin instructions were emitted (see https://github.com/ocaml/opam-repository/pull/18970)
- Also update CHANGES