### PR TITLE
Lower OCaml version to 4.02.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 - Update licensing metadata.
 - Update dune files to 2.7 to autogenerate opam files correctly (#2)
+- Lower OCaml version to 4.02.3
 
 # Release 5.0  (2021-06-29)
 

--- a/camlp-streams.opam
+++ b/camlp-streams.opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/ocaml/camlp-streams"
 bug-reports: "https://github.com/ocaml/camlp-streams/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.02.3"}
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -35,5 +35,5 @@ but will be maintained and distributed separately in this camlpstreams package.
 ")
 
  (depends
-  (ocaml (>= 4.05.0)))
+  (ocaml (>= 4.02.3)))
 )


### PR DESCRIPTION
Since `Stream` is going to be deprecated in OCaml 4.14 in Yojson to deal with this we wanted to switch to camlp-streams for now, until we get time to adjust the API. This would allow us to stay compatible for a while longer.

But we support 4.02.3 as minimum version, so to avoid a complicated build headache of switching between the Stdlib-Stream and this Stream library it would be better if this library supported 4.02.3.

Given the code hasn't been touched in (probably) a long time it was my hunch that it should also build on older OCaml versions and, testing it on a 4.02.3 switch, that seems to have been correct.

Hence here's a PR to lower the minimum required OCaml version.