### PR TITLE
Fix the build for 4.02-4.04 on macOS and for 4.02-4.10 with MSVC on Windows

### DIFF
--- a/dune
+++ b/dune
@@ -1,63 +1,72 @@
-(* -*- tuareg -*- *)
+; camlp-streams is built in three different ways, depending on the version of
+; OCaml it's built for:
+; - 4.07 and earlier: empty library; Standard Library Stream and Genlex used
+;   directly, since it's not possible in these versions to override the modules
+; - 4.08-4.14: Standard Library Stream and Genlex re-exported (without
+;   deprecation for 4.14)
+; - 5.0+: modules in src/ are compiled
 
-(* camlp-streams is built in three different ways, depending on the version of
-   OCaml it's built for:
-   - 4.07 and earlier: empty library; Standard Library Stream and Genlex used
-     directly, since it's not possible in these versions to override the modules
-   - 4.08-4.14: Standard Library Stream and Genlex re-exported (without
-     deprecation for 4.14)
-   - 5.0+: modules in src/ are compiled
- *)
-
-open Jbuild_plugin.V1
-
-let modules =
-  let version = Scanf.sscanf ocaml_version "%u.%u" (fun a b -> (a, b)) in
-  if version >= (4, 08) then ":standard" else ""
-
-let dune_fragment_for mod_name basename =
-  Printf.sprintf {|
+; Use the files in src/ for OCaml 5.0+
 (rule
-  (target %s.mli)
-  (action (copy src/%%{target} %%{target}))
-  (enabled_if (>= %%{ocaml_version} 5.0)))
+  (target stream.mli)
+  (action (copy src/%{target} %{target}))
+  (enabled_if (>= %{ocaml_version} 5.0)))
 
 (rule
-  (target %s.ml)
-  (action (copy src/%%{target} %%{target}))
-  (enabled_if (>= %%{ocaml_version} 5.0)))
+  (target stream.ml)
+  (action (copy src/%{target} %{target}))
+  (enabled_if (>= %{ocaml_version} 5.0)))
 
 (rule
-  (target %s.mli)
-  (action (with-stdout-to %%{target}
-    (echo "include module type of struct include %s end")))
-  (enabled_if (< %%{ocaml_version} 5.0)))
+  (target genlex.mli)
+  (action (copy src/%{target} %{target}))
+  (enabled_if (>= %{ocaml_version} 5.0)))
 
 (rule
-  (target %s.ml)
-  (action (with-stdout-to %%{target}
-    (echo "include %s")))
-  (enabled_if (< %%{ocaml_version} 5.0)))|}
-    basename basename basename mod_name basename mod_name
+  (target genlex.ml)
+  (action (copy src/%{target} %{target}))
+  (enabled_if (>= %{ocaml_version} 5.0)))
 
-let () =
-  let stream = dune_fragment_for "Stream" "stream" in
-  let genlex = dune_fragment_for "Genlex" "genlex" in
-  Printf.ksprintf send {|
-%s %s
 (rule
   (action (with-stdout-to flags.sexp (echo "(-w -9)")))
-  (enabled_if (>= %%{ocaml_version} 5.0)))
+  (enabled_if (>= %{ocaml_version} 5.0)))
+
+; Re-export Stream and Genlex directly in OCaml 4.08-4.14
+(rule
+  (target stream.mli)
+  (action (with-stdout-to %{target}
+    (echo "include module type of struct include Stream end")))
+  (enabled_if (and (>= %{ocaml_version} 4.08) (< %{ocaml_version} 5.0))))
+
+(rule
+  (target stream.ml)
+  (action (with-stdout-to %{target}
+    (echo "include Stream")))
+  (enabled_if (and (>= %{ocaml_version} 4.08) (< %{ocaml_version} 5.0))))
+
+(rule
+  (target genlex.mli)
+  (action (with-stdout-to %{target}
+    (echo "include module type of struct include Genlex end")))
+  (enabled_if (and (>= %{ocaml_version} 4.08) (< %{ocaml_version} 5.0))))
+
+(rule
+  (target genlex.ml)
+  (action (with-stdout-to %{target}
+    (echo "include Genlex")))
+  (enabled_if (and (>= %{ocaml_version} 4.08) (< %{ocaml_version} 5.0))))
+
 (rule
   (action (with-stdout-to flags.sexp (echo "(-w -3)")))
-  (enabled_if (and (>= %%{ocaml_version} 4.14) (< %%{ocaml_version} 5.0))))
+  (enabled_if (and (>= %{ocaml_version} 4.14) (< %{ocaml_version} 5.0))))
+
+; Do nothing for OCaml 4.07 and earlier - Dune will then create an empty library
 (rule
   (action (with-stdout-to flags.sexp (echo "()")))
-  (enabled_if (< %%{ocaml_version} 4.14)))
+  (enabled_if (< %{ocaml_version} 4.14)))
 
 (library
   (name camlp_streams)
   (public_name camlp-streams)
-  (modules %s)
   (wrapped false)
-  (flags :standard (:include flags.sexp)))|} stream genlex modules
+  (flags :standard (:include flags.sexp)))

--- a/dune
+++ b/dune
@@ -28,7 +28,8 @@
   (enabled_if (>= %{ocaml_version} 5.0)))
 
 (rule
-  (action (with-stdout-to flags.sexp (echo "(-w -9)")))
+  (target flags.sexp)
+  (action (copy src/%{target} %{target}))
   (enabled_if (>= %{ocaml_version} 5.0)))
 
 ; Re-export Stream and Genlex directly in OCaml 4.08-4.14

--- a/dune
+++ b/dune
@@ -1,9 +1,8 @@
 ; camlp-streams is built in three different ways, depending on the version of
 ; OCaml it's built for:
-; - 4.07 and earlier: empty library; Standard Library Stream and Genlex used
+; - 4.13 and earlier: empty library; Standard Library Stream and Genlex used
 ;   directly, since it's not possible in these versions to override the modules
-; - 4.08-4.14: Standard Library Stream and Genlex re-exported (without
-;   deprecation for 4.14)
+; - 4.14: Standard Library Stream and Genlex re-exported without deprecation
 ; - 5.0+: modules in src/ are compiled
 
 ; Use the files in src/ for OCaml 5.0+
@@ -32,36 +31,38 @@
   (action (copy src/%{target} %{target}))
   (enabled_if (>= %{ocaml_version} 5.0)))
 
-; Re-export Stream and Genlex directly in OCaml 4.08-4.14
+; Re-export Stream and Genlex directly in OCaml 4.14 to remove the deprecation
+; warning
 (rule
   (target stream.mli)
   (action (with-stdout-to %{target}
     (echo "include module type of struct include Stream end")))
-  (enabled_if (and (>= %{ocaml_version} 4.08) (< %{ocaml_version} 5.0))))
+  (enabled_if (and (>= %{ocaml_version} 4.14) (< %{ocaml_version} 5.0))))
 
 (rule
   (target stream.ml)
   (action (with-stdout-to %{target}
     (echo "include Stream")))
-  (enabled_if (and (>= %{ocaml_version} 4.08) (< %{ocaml_version} 5.0))))
+  (enabled_if (and (>= %{ocaml_version} 4.14) (< %{ocaml_version} 5.0))))
 
 (rule
   (target genlex.mli)
   (action (with-stdout-to %{target}
     (echo "include module type of struct include Genlex end")))
-  (enabled_if (and (>= %{ocaml_version} 4.08) (< %{ocaml_version} 5.0))))
+  (enabled_if (and (>= %{ocaml_version} 4.14) (< %{ocaml_version} 5.0))))
 
 (rule
   (target genlex.ml)
   (action (with-stdout-to %{target}
     (echo "include Genlex")))
-  (enabled_if (and (>= %{ocaml_version} 4.08) (< %{ocaml_version} 5.0))))
+  (enabled_if (and (>= %{ocaml_version} 4.14) (< %{ocaml_version} 5.0))))
 
 (rule
   (action (with-stdout-to flags.sexp (echo "(-w -3)")))
   (enabled_if (and (>= %{ocaml_version} 4.14) (< %{ocaml_version} 5.0))))
 
-; Do nothing for OCaml 4.07 and earlier - Dune will then create an empty library
+; Do nothing for OCaml 4.13 and earlier - Dune will then create an empty library
+
 (rule
   (action (with-stdout-to flags.sexp (echo "()")))
   (enabled_if (< %{ocaml_version} 4.14)))

--- a/dune
+++ b/dune
@@ -4,6 +4,9 @@
 ;   directly, since it's not possible in these versions to override the modules
 ; - 4.14: Standard Library Stream and Genlex re-exported without deprecation
 ; - 5.0+: modules in src/ are compiled
+; Note that on OCaml 4.10 and earlier for MSVC and 4.04 and earlier for macOS, a
+; dummy module CamlinternalCamlp_streams is added to workaround the inability to
+; create empty .cmxa files on both those platforms.
 
 ; Use the files in src/ for OCaml 5.0+
 (rule
@@ -62,6 +65,17 @@
   (enabled_if (and (>= %{ocaml_version} 4.14) (< %{ocaml_version} 5.0))))
 
 ; Do nothing for OCaml 4.13 and earlier - Dune will then create an empty library
+; OCaml 4.04 on macOS and OCaml 4.10 and earlier with the Microsoft C compiler
+; on Windows cannot create empty .cmxa files. On these specific systems and
+; versions, the empty module CamlinternalCamlp_streams is created. This name
+; doesn't conflict with the official compiler release and modules prefixed
+; Camlinternal are not supposed to be created outside the compiler distribution.
+
+(rule
+  (target camlinternalCamlp_streams.ml)
+  (action (with-stdout-to %{target} (echo "")))
+  (enabled_if (or (and (< %{ocaml_version} 4.11) (= %{ocaml-config:ccomp_type} msvc))
+                  (and (< %{ocaml_version} 4.05) (= %{system} macosx)))))
 
 (rule
   (action (with-stdout-to flags.sexp (echo "()")))

--- a/dune
+++ b/dune
@@ -58,7 +58,7 @@
   (enabled_if (and (>= %{ocaml_version} 4.14) (< %{ocaml_version} 5.0))))
 
 (rule
-  (action (with-stdout-to flags.sexp (echo "(-w -3)")))
+  (action (with-stdout-to flags.sexp (echo "(-alert -deprecated)")))
   (enabled_if (and (>= %{ocaml_version} 4.14) (< %{ocaml_version} 5.0))))
 
 ; Do nothing for OCaml 4.13 and earlier - Dune will then create an empty library

--- a/src/flags.sexp
+++ b/src/flags.sexp
@@ -1,2 +1,2 @@
 ; The code requires warning 9 to be disabled
-(-w -9)
+(-w -missing-record-field-pattern)

--- a/src/flags.sexp
+++ b/src/flags.sexp
@@ -1,0 +1,2 @@
+; The code requires warning 9 to be disabled
+(-w -9)


### PR DESCRIPTION
I recently discovered that one can correctly trick Dune into creating empty libraries for some versions of OCaml, which allows the removal of the dynamic `dune` file. This PR then changes the build to be an empty library for OCaml 4.13 and earlier. This was originally considered in #5, but it breaks the build on MSVC prior to 4.11, so instead an empty library was only built for OCaml 4.07 to limit the damage to 4.02-4.07 on MSVC. It turns out the damage included in 4.02-4.04 on macOS.

The solution proposed here is that for the offending versions of OCaml (that's 4.02-4.04 on macOS and 4.02-4.10 with MSVC on Windows), an empty module `CamlinternalCamlp_streams` is added to the library which works around the linker problems.

A solution such as this was considered for the same problem in stdlib-shims, however it was rejected there because this issue affects the _current_ versions of OCaml (the solution adopted in stdlib-shims was to fix OCaml itself). I think it's OK to use this trick here because we know that there was no `CamlinternalCamlp_streams` module in 4.02-4.10 and programs and libraries are not supposed to use names beginning `Camlinternal`. Most importantly, the number of releases in which this trick is used is fixed, unlike in stdlib-shims.